### PR TITLE
fix: correct page detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,11 +54,7 @@ async function openRandomNote() {
     const pages = ret?.flat();
     for (let i = 0; i < pages.length; i++) {
       const block = pages[i];
-      if (
-        block.parent && block.page &&
-        block.parent?.id === block.page?.id &&
-        (await logseq.Editor.getPreviousSiblingBlock(block.uuid)) == null
-      ) {
+      if (block["pre-block?"]) {
         pages[i] = await logseq.Editor.getPage(block.page.id);
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-random-note",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": "TankCool",
   "main": "dist/index.html",
   "description": "Random walk through your Logseq notes.",


### PR DESCRIPTION
I found this `pre-block? field, it better identifies whether a block is a page's metadata block.